### PR TITLE
Downgrade pyparsing for matplotlib compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ psutil==5.9.5
 ptyprocess==0.7.0
 pure-eval==0.2.2
 Pygments==2.15.1
-pyparsing==3.1.0
+pyparsing==3.0.9
 python-dateutil==2.8.2
 pytz==2023.3
 pyzmq==25.1.0


### PR DESCRIPTION
Matplotlib 3.7.2 requires pyparsing to be <3.1